### PR TITLE
[A3.2] Rate limiting cho auth routes (express-rate-limit)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
     "better-sqlite3": "^12.9.0",
     "cors": "^2.8.5",
     "express": "^4.21.0",
+    "express-rate-limit": "^7.4.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.1"
   },

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -6,6 +6,7 @@ import usersRouter from './routes/users.js';
 import worldsRouter from './routes/worlds.js';
 import eventsRouter from './routes/events.js';
 import postsRouter from './routes/posts.js';
+import { globalApiRateLimiter } from './middleware/rateLimiter.js';
 
 // Initialize database tables
 initDatabase();
@@ -14,6 +15,7 @@ const app = express();
 
 app.use(cors({ origin: config.corsOrigin }));
 app.use(express.json());
+app.use(globalApiRateLimiter);
 
 app.use('/api/users', usersRouter);
 app.use('/api/worlds', worldsRouter);

--- a/server/src/middleware/rateLimiter.js
+++ b/server/src/middleware/rateLimiter.js
@@ -1,0 +1,35 @@
+import rateLimit from 'express-rate-limit';
+
+const rateLimitHandler = (req, res) => {
+  res.status(429).json({
+    error: 'RATE_LIMIT_EXCEEDED',
+    message: 'Too many requests, please try again later.',
+    retryAfter: Math.ceil(req.rateLimit.resetTime / 1000),
+  });
+};
+
+export const authRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: rateLimitHandler,
+  message: 'Too many authentication attempts, please try again after 15 minutes.',
+});
+
+export const registerRateLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: rateLimitHandler,
+  message: 'Too many registration attempts, please try again after 1 hour.',
+});
+
+export const globalApiRateLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: rateLimitHandler,
+});

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -2,10 +2,11 @@ import { Router } from 'express';
 import bcrypt from 'bcryptjs';
 import db from '../database/connection.js';
 import { generateToken, authMiddleware } from '../config/auth.js';
+import { authRateLimiter, registerRateLimiter } from '../middleware/rateLimiter.js';
 
 const router = Router();
 
-router.post('/register', (req, res) => {
+router.post('/register', registerRateLimiter, (req, res) => {
   const { username, email, password, display_name } = req.body;
   if (!username || !email || !password || !display_name) {
     return res.status(400).json({ error: 'All fields are required' });
@@ -26,7 +27,7 @@ router.post('/register', (req, res) => {
   res.status(201).json({ user, token: generateToken(user) });
 });
 
-router.post('/login', (req, res) => {
+router.post('/login', authRateLimiter, (req, res) => {
   const { username, password } = req.body;
   if (!username || !password) {
     return res.status(400).json({ error: 'Username and password required' });


### PR DESCRIPTION
Closes #218

## Summary

- Thêm `express-rate-limit@7.4.0` dependency
- Rate limiting 3 tầng: register (5/hr), login (10/15min), global (100/min)
- Response JSON chuẩn với `RATE_LIMIT_EXCEEDED` và `retryAfter`

## Changes

| File | Thay đổi |
|------|---------|
| `server/src/middleware/rateLimiter.js` | 3 limiters: register, auth, global |
| `server/src/routes/users.js` | Apply per-route limiters |
| `server/src/index.js` | Apply global limiter |
| `server/package.json` | Add express-rate-limit |

## Rate Limit Config

| Endpoint | Window | Max |
|----------|--------|-----|
| `/api/users/register` | 1 hour | 5 |
| `/api/users/login` | 15 min | 10 |
| All API routes | 1 min | 100 |

## Test Plan

- [ ] Gọi `/login` 11 lần liên tiếp → lần thứ 11 trả về 429
- [ ] Response body có `error: "RATE_LIMIT_EXCEEDED"` và `retryAfter`
- [ ] Response headers có `RateLimit-Limit`, `RateLimit-Remaining`