### PR TITLE
[A3.5] Tối ưu database queries (indexes, prepared statements)

### DIFF
--- a/server/src/database/queries.js
+++ b/server/src/database/queries.js
@@ -1,0 +1,76 @@
+import db from './connection.js';
+
+// Reusable prepared statements — prepared once, executed many times.
+// better-sqlite3 caches prepared statements per connection, but explicit
+// module-level constants make the hot paths obvious and avoid re-preparing
+// on every request in hot loops.
+
+export const stmts = {
+  // users
+  getUserById: db.prepare(
+    'SELECT id, username, email, display_name, avatar_url, created_at FROM users WHERE id = ?',
+  ),
+  getUserByUsername: db.prepare('SELECT * FROM users WHERE username = ?'),
+  getUserByUsernameOrEmail: db.prepare(
+    'SELECT id FROM users WHERE username = ? OR email = ?',
+  ),
+  insertUser: db.prepare(
+    'INSERT INTO users (username, email, password, display_name) VALUES (?, ?, ?, ?)',
+  ),
+
+  // worlds
+  getWorldById: db.prepare(
+    `SELECT w.*, (SELECT COUNT(*) FROM world_members WHERE world_id = w.id AND status = 'approved') as member_count FROM worlds w WHERE w.id = ?`,
+  ),
+  insertWorld: db.prepare(
+    'INSERT INTO worlds (title, description, is_public) VALUES (?, ?, ?)',
+  ),
+
+  // world_members
+  getMembership: db.prepare(
+    'SELECT * FROM world_members WHERE world_id = ? AND user_id = ?',
+  ),
+  getDevMembership: db.prepare(
+    "SELECT * FROM world_members WHERE world_id = ? AND user_id = ? AND role = 'dev' AND status = 'approved'",
+  ),
+  getApprovedMembership: db.prepare(
+    "SELECT * FROM world_members WHERE world_id = ? AND user_id = ? AND status = 'approved'",
+  ),
+  insertMember: db.prepare(
+    "INSERT INTO world_members (world_id, user_id, role, status) VALUES (?, ?, ?, ?)",
+  ),
+  updateMemberStatus: db.prepare(
+    'UPDATE world_members SET status = ? WHERE id = ? AND world_id = ?',
+  ),
+  updateMemberCredits: db.prepare(
+    'UPDATE world_members SET credits = credits + ? WHERE world_id = ? AND user_id = ?',
+  ),
+
+  // posts
+  getPostById: db.prepare('SELECT * FROM posts WHERE id = ?'),
+  insertPost: db.prepare(
+    'INSERT INTO posts (event_id, world_id, user_id, content, image_url, status) VALUES (?, ?, ?, ?, ?, ?)',
+  ),
+  updatePostStatus: db.prepare(
+    "UPDATE posts SET status = ? WHERE id = ? AND status = 'pending'",
+  ),
+  updatePostContent: db.prepare('UPDATE posts SET content = ? WHERE id = ?'),
+  deletePost: db.prepare('DELETE FROM posts WHERE id = ?'),
+
+  // comments
+  insertComment: db.prepare(
+    'INSERT INTO comments (post_id, user_id, content) VALUES (?, ?, ?)',
+  ),
+
+  // likes
+  getLike: db.prepare(
+    'SELECT id FROM likes WHERE post_id = ? AND user_id = ?',
+  ),
+  insertLike: db.prepare(
+    'INSERT INTO likes (post_id, user_id) VALUES (?, ?)',
+  ),
+  deleteLike: db.prepare('DELETE FROM likes WHERE id = ?'),
+
+  // events
+  getEventById: db.prepare('SELECT * FROM events WHERE id = ?'),
+};

--- a/server/src/database/schema.js
+++ b/server/src/database/schema.js
@@ -97,5 +97,23 @@ export function initDatabase() {
       FOREIGN KEY(world_id) REFERENCES worlds(id) ON DELETE CASCADE,
       FOREIGN KEY(user_id) REFERENCES users(id)
     );
+
+    -- Indexes for frequently queried columns
+    CREATE INDEX IF NOT EXISTS idx_world_members_world_id ON world_members(world_id);
+    CREATE INDEX IF NOT EXISTS idx_world_members_user_id ON world_members(user_id);
+    CREATE INDEX IF NOT EXISTS idx_world_members_world_user ON world_members(world_id, user_id);
+    CREATE INDEX IF NOT EXISTS idx_world_members_status ON world_members(world_id, status);
+    CREATE INDEX IF NOT EXISTS idx_events_world_id ON events(world_id);
+    CREATE INDEX IF NOT EXISTS idx_events_status ON events(world_id, status);
+    CREATE INDEX IF NOT EXISTS idx_posts_event_id ON posts(event_id);
+    CREATE INDEX IF NOT EXISTS idx_posts_world_id ON posts(world_id);
+    CREATE INDEX IF NOT EXISTS idx_posts_world_status ON posts(world_id, status);
+    CREATE INDEX IF NOT EXISTS idx_posts_event_status ON posts(event_id, status);
+    CREATE INDEX IF NOT EXISTS idx_comments_post_id ON comments(post_id);
+    CREATE INDEX IF NOT EXISTS idx_likes_post_user ON likes(post_id, user_id);
+    CREATE INDEX IF NOT EXISTS idx_likes_comment_user ON likes(comment_id, user_id);
+    CREATE INDEX IF NOT EXISTS idx_announcements_world_id ON announcements(world_id);
+    CREATE INDEX IF NOT EXISTS idx_worlds_public_created ON worlds(is_public, created_at);
   `);
 }
+


### PR DESCRIPTION
Closes #221

## Summary

- Thêm 15 covering indexes cho hot query paths
- Tạo `queries.js` module với module-level prepared statements

## Changes

| File | Thay đổi |
|------|---------|
| `server/src/database/schema.js` | 15 indexes với `CREATE INDEX IF NOT EXISTS` |
| `server/src/database/queries.js` | Reusable prepared statements cho tất cả hot paths |

## Indexes Added

```sql
-- world_members (most queried)
idx_world_members_world_id, idx_world_members_user_id,
idx_world_members_world_user (composite), idx_world_members_status (composite)

-- events, posts
idx_events_world_id, idx_events_status, idx_posts_event_id,
idx_posts_world_id, idx_posts_world_status, idx_posts_event_status

-- comments, likes, announcements, worlds
idx_comments_post_id, idx_likes_post_user, idx_likes_comment_user,
idx_announcements_world_id, idx_worlds_public_created
```

## Test Plan

- [ ] Server start không lỗi với schema mới
- [ ] `EXPLAIN QUERY PLAN` trên `world_members WHERE world_id=? AND status=?` → dùng index
- [ ] Restart server nhiều lần → không lỗi (IF NOT EXISTS)