### PR TITLE
[A3.6] Tests cho input validation và rate limiting

### DIFF
--- a/server/src/test/helpers/appContext.js
+++ b/server/src/test/helpers/appContext.js
@@ -1,0 +1,26 @@
+import { setupTestDb, cleanupTestDb, resetDatabase } from './testDb.js';
+
+export function createAppContext() {
+  const ctx = { app: null, db: null, testDbPath: null };
+
+  beforeAll(async () => {
+    ctx.testDbPath = setupTestDb();
+    const dbModule = await import('../../database/connection.js');
+    ctx.db = dbModule.default;
+    const schemaModule = await import('../../database/schema.js');
+    schemaModule.initDatabase();
+    const appModule = await import('../../index.js');
+    ctx.app = appModule.default;
+  });
+
+  beforeEach(() => {
+    resetDatabase(ctx.db);
+  });
+
+  afterAll(() => {
+    if (ctx.db) ctx.db.close();
+    cleanupTestDb(ctx.testDbPath);
+  });
+
+  return ctx;
+}

--- a/server/src/test/rateLimiter.test.js
+++ b/server/src/test/rateLimiter.test.js
@@ -1,65 +1,35 @@
 import request from 'supertest';
-import { cleanupTestDb, resetDatabase, setupTestDb } from './helpers/testDb.js';
+import { createAppContext } from './helpers/appContext.js';
 
 describe('Rate Limiting Tests', () => {
-  let app;
-  let db;
-  let testDbPath;
-
-  beforeAll(async () => {
-    testDbPath = setupTestDb();
-    const dbModule = await import('../database/connection.js');
-    db = dbModule.default;
-    const schemaModule = await import('../database/schema.js');
-    schemaModule.initDatabase();
-    const appModule = await import('../index.js');
-    app = appModule.default;
-  });
-
-  beforeEach(() => {
-    resetDatabase(db);
-  });
-
-  afterAll(() => {
-    if (db) db.close();
-    cleanupTestDb(testDbPath);
-  });
+  const ctx = createAppContext();
 
   describe('POST /api/users/login - auth rate limiter', () => {
     const loginPayload = { username: 'nonexistent', password: 'wrongpass' };
 
     test('allows requests under the rate limit', async () => {
-      const res = await request(app).post('/api/users/login').send(loginPayload);
-      // Should get 401 (bad credentials), not 429 (rate limited)
+      const res = await request(ctx.app).post('/api/users/login').send(loginPayload);
       expect(res.status).not.toBe(429);
     });
 
     test('responds with 429 and structured error after exceeding auth limit', async () => {
-      const MAX_ATTEMPTS = 10;
       let lastRes;
-
-      for (let i = 0; i <= MAX_ATTEMPTS; i++) {
-        lastRes = await request(app).post('/api/users/login').send(loginPayload);
+      for (let i = 0; i <= 10; i++) {
+        lastRes = await request(ctx.app).post('/api/users/login').send(loginPayload);
       }
-
       expect(lastRes.status).toBe(429);
       expect(lastRes.body).toHaveProperty('error', 'RATE_LIMIT_EXCEEDED');
       expect(lastRes.body).toHaveProperty('message');
     });
 
     test('429 response includes RateLimit headers', async () => {
-      const MAX_ATTEMPTS = 10;
       let lastRes;
-      for (let i = 0; i <= MAX_ATTEMPTS; i++) {
-        lastRes = await request(app).post('/api/users/login').send(loginPayload);
+      for (let i = 0; i <= 10; i++) {
+        lastRes = await request(ctx.app).post('/api/users/login').send(loginPayload);
       }
-
       expect(lastRes.status).toBe(429);
-      // express-rate-limit with standardHeaders=true sets RateLimit-* headers
       expect(lastRes.headers).toMatchObject(
-        expect.objectContaining({
-          'ratelimit-limit': expect.any(String),
-        }),
+        expect.objectContaining({ 'ratelimit-limit': expect.any(String) }),
       );
     });
   });
@@ -73,22 +43,15 @@ describe('Rate Limiting Tests', () => {
     });
 
     test('allows registrations under the hourly limit', async () => {
-      const res = await request(app)
-        .post('/api/users/register')
-        .send(makePayload(1));
+      const res = await request(ctx.app).post('/api/users/register').send(makePayload(1));
       expect(res.status).not.toBe(429);
     });
 
     test('responds with 429 after exceeding register limit', async () => {
-      const MAX_ATTEMPTS = 5;
       let lastRes;
-
-      for (let i = 0; i <= MAX_ATTEMPTS; i++) {
-        lastRes = await request(app)
-          .post('/api/users/register')
-          .send(makePayload(i + 100));
+      for (let i = 0; i <= 5; i++) {
+        lastRes = await request(ctx.app).post('/api/users/register').send(makePayload(i + 100));
       }
-
       expect(lastRes.status).toBe(429);
       expect(lastRes.body.error).toBe('RATE_LIMIT_EXCEEDED');
     });
@@ -96,18 +59,15 @@ describe('Rate Limiting Tests', () => {
 
   describe('Global API rate limiter', () => {
     test('health endpoint is rate-limited after 100 req/min', async () => {
-      const GLOBAL_LIMIT = 100;
       let lastRes;
-
-      for (let i = 0; i <= GLOBAL_LIMIT; i++) {
-        lastRes = await request(app).get('/api/health');
+      for (let i = 0; i <= 100; i++) {
+        lastRes = await request(ctx.app).get('/api/health');
       }
-
       expect(lastRes.status).toBe(429);
     });
 
     test('non-rate-limited response has RateLimit headers', async () => {
-      const res = await request(app).get('/api/health');
+      const res = await request(ctx.app).get('/api/health');
       expect(res.status).toBe(200);
       expect(res.headers).toHaveProperty('ratelimit-limit');
     });

--- a/server/src/test/rateLimiter.test.js
+++ b/server/src/test/rateLimiter.test.js
@@ -1,0 +1,115 @@
+import request from 'supertest';
+import { cleanupTestDb, resetDatabase, setupTestDb } from './helpers/testDb.js';
+
+describe('Rate Limiting Tests', () => {
+  let app;
+  let db;
+  let testDbPath;
+
+  beforeAll(async () => {
+    testDbPath = setupTestDb();
+    const dbModule = await import('../database/connection.js');
+    db = dbModule.default;
+    const schemaModule = await import('../database/schema.js');
+    schemaModule.initDatabase();
+    const appModule = await import('../index.js');
+    app = appModule.default;
+  });
+
+  beforeEach(() => {
+    resetDatabase(db);
+  });
+
+  afterAll(() => {
+    if (db) db.close();
+    cleanupTestDb(testDbPath);
+  });
+
+  describe('POST /api/users/login - auth rate limiter', () => {
+    const loginPayload = { username: 'nonexistent', password: 'wrongpass' };
+
+    test('allows requests under the rate limit', async () => {
+      const res = await request(app).post('/api/users/login').send(loginPayload);
+      // Should get 401 (bad credentials), not 429 (rate limited)
+      expect(res.status).not.toBe(429);
+    });
+
+    test('responds with 429 and structured error after exceeding auth limit', async () => {
+      const MAX_ATTEMPTS = 10;
+      let lastRes;
+
+      for (let i = 0; i <= MAX_ATTEMPTS; i++) {
+        lastRes = await request(app).post('/api/users/login').send(loginPayload);
+      }
+
+      expect(lastRes.status).toBe(429);
+      expect(lastRes.body).toHaveProperty('error', 'RATE_LIMIT_EXCEEDED');
+      expect(lastRes.body).toHaveProperty('message');
+    });
+
+    test('429 response includes RateLimit headers', async () => {
+      const MAX_ATTEMPTS = 10;
+      let lastRes;
+      for (let i = 0; i <= MAX_ATTEMPTS; i++) {
+        lastRes = await request(app).post('/api/users/login').send(loginPayload);
+      }
+
+      expect(lastRes.status).toBe(429);
+      // express-rate-limit with standardHeaders=true sets RateLimit-* headers
+      expect(lastRes.headers).toMatchObject(
+        expect.objectContaining({
+          'ratelimit-limit': expect.any(String),
+        }),
+      );
+    });
+  });
+
+  describe('POST /api/users/register - register rate limiter', () => {
+    const makePayload = (n) => ({
+      username: `ratelimituser${n}`,
+      email: `ratelimit${n}@example.com`,
+      password: 'Password123',
+      display_name: `Rate Limit User ${n}`,
+    });
+
+    test('allows registrations under the hourly limit', async () => {
+      const res = await request(app)
+        .post('/api/users/register')
+        .send(makePayload(1));
+      expect(res.status).not.toBe(429);
+    });
+
+    test('responds with 429 after exceeding register limit', async () => {
+      const MAX_ATTEMPTS = 5;
+      let lastRes;
+
+      for (let i = 0; i <= MAX_ATTEMPTS; i++) {
+        lastRes = await request(app)
+          .post('/api/users/register')
+          .send(makePayload(i + 100));
+      }
+
+      expect(lastRes.status).toBe(429);
+      expect(lastRes.body.error).toBe('RATE_LIMIT_EXCEEDED');
+    });
+  });
+
+  describe('Global API rate limiter', () => {
+    test('health endpoint is rate-limited after 100 req/min', async () => {
+      const GLOBAL_LIMIT = 100;
+      let lastRes;
+
+      for (let i = 0; i <= GLOBAL_LIMIT; i++) {
+        lastRes = await request(app).get('/api/health');
+      }
+
+      expect(lastRes.status).toBe(429);
+    });
+
+    test('non-rate-limited response has RateLimit headers', async () => {
+      const res = await request(app).get('/api/health');
+      expect(res.status).toBe(200);
+      expect(res.headers).toHaveProperty('ratelimit-limit');
+    });
+  });
+});

--- a/server/src/test/validation.test.js
+++ b/server/src/test/validation.test.js
@@ -1,69 +1,47 @@
 import request from 'supertest';
-import { cleanupTestDb, resetDatabase, setupTestDb } from './helpers/testDb.js';
+import { createAppContext } from './helpers/appContext.js';
 
 describe('Input Validation Tests', () => {
-  let app;
-  let db;
-  let testDbPath;
+  const ctx = createAppContext();
 
-  beforeAll(async () => {
-    testDbPath = setupTestDb();
-    const dbModule = await import('../database/connection.js');
-    db = dbModule.default;
-    const schemaModule = await import('../database/schema.js');
-    schemaModule.initDatabase();
-    const appModule = await import('../index.js');
-    app = appModule.default;
-  });
+  const validUser = {
+    username: 'validuser',
+    email: 'valid@example.com',
+    password: 'Password123',
+    display_name: 'Valid User',
+  };
 
-  beforeEach(() => {
-    resetDatabase(db);
-  });
-
-  afterAll(() => {
-    if (db) db.close();
-    cleanupTestDb(testDbPath);
-  });
-
-  // --- Register validation ---
   describe('POST /api/users/register', () => {
-    const validUser = {
-      username: 'validuser',
-      email: 'valid@example.com',
-      password: 'Password123',
-      display_name: 'Valid User',
-    };
-
     test('rejects missing username', async () => {
       const { username, ...body } = validUser;
-      const res = await request(app).post('/api/users/register').send(body);
+      const res = await request(ctx.app).post('/api/users/register').send(body);
       expect(res.status).toBe(400);
       expect(res.body.error).toBeDefined();
     });
 
     test('rejects username shorter than 3 chars', async () => {
-      const res = await request(app)
+      const res = await request(ctx.app)
         .post('/api/users/register')
         .send({ ...validUser, username: 'ab' });
       expect(res.status).toBe(400);
     });
 
     test('rejects username with special characters', async () => {
-      const res = await request(app)
+      const res = await request(ctx.app)
         .post('/api/users/register')
         .send({ ...validUser, username: 'bad user!' });
       expect(res.status).toBe(400);
     });
 
     test('rejects invalid email format', async () => {
-      const res = await request(app)
+      const res = await request(ctx.app)
         .post('/api/users/register')
         .send({ ...validUser, email: 'not-an-email' });
       expect(res.status).toBe(400);
     });
 
     test('rejects password shorter than 6 chars', async () => {
-      const res = await request(app)
+      const res = await request(ctx.app)
         .post('/api/users/register')
         .send({ ...validUser, password: '12345' });
       expect(res.status).toBe(400);
@@ -71,45 +49,39 @@ describe('Input Validation Tests', () => {
 
     test('rejects missing display_name', async () => {
       const { display_name, ...body } = validUser;
-      const res = await request(app).post('/api/users/register').send(body);
+      const res = await request(ctx.app).post('/api/users/register').send(body);
       expect(res.status).toBe(400);
     });
 
     test('accepts valid registration payload', async () => {
-      const res = await request(app).post('/api/users/register').send(validUser);
+      const res = await request(ctx.app).post('/api/users/register').send(validUser);
       expect(res.status).toBe(201);
       expect(res.body).toHaveProperty('token');
     });
   });
 
-  // --- Login validation ---
   describe('POST /api/users/login', () => {
     test('rejects missing username', async () => {
-      const res = await request(app)
-        .post('/api/users/login')
-        .send({ password: 'pass' });
+      const res = await request(ctx.app).post('/api/users/login').send({ password: 'pass' });
       expect(res.status).toBe(400);
     });
 
     test('rejects missing password', async () => {
-      const res = await request(app)
-        .post('/api/users/login')
-        .send({ username: 'user' });
+      const res = await request(ctx.app).post('/api/users/login').send({ username: 'user' });
       expect(res.status).toBe(400);
     });
 
     test('rejects empty body', async () => {
-      const res = await request(app).post('/api/users/login').send({});
+      const res = await request(ctx.app).post('/api/users/login').send({});
       expect(res.status).toBe(400);
     });
   });
 
-  // --- World creation validation ---
   describe('POST /api/worlds', () => {
     let token;
 
     beforeEach(async () => {
-      const reg = await request(app).post('/api/users/register').send({
+      const reg = await request(ctx.app).post('/api/users/register').send({
         username: 'worlddev',
         email: 'worlddev@example.com',
         password: 'Password123',
@@ -119,7 +91,7 @@ describe('Input Validation Tests', () => {
     });
 
     test('rejects missing title', async () => {
-      const res = await request(app)
+      const res = await request(ctx.app)
         .post('/api/worlds')
         .set('Authorization', `Bearer ${token}`)
         .send({ description: 'No title' });
@@ -127,7 +99,7 @@ describe('Input Validation Tests', () => {
     });
 
     test('accepts valid world creation', async () => {
-      const res = await request(app)
+      const res = await request(ctx.app)
         .post('/api/worlds')
         .set('Authorization', `Bearer ${token}`)
         .send({ title: 'Test World', description: 'A world', is_public: true });
@@ -135,7 +107,7 @@ describe('Input Validation Tests', () => {
     });
 
     test('rejects is_public with non-boolean value', async () => {
-      const res = await request(app)
+      const res = await request(ctx.app)
         .post('/api/worlds')
         .set('Authorization', `Bearer ${token}`)
         .send({ title: 'World', is_public: 'yes' });
@@ -143,13 +115,12 @@ describe('Input Validation Tests', () => {
     });
   });
 
-  // --- Post validation ---
   describe('POST /api/posts/event/:eventId', () => {
     let token;
     let eventId;
 
     beforeEach(async () => {
-      const reg = await request(app).post('/api/users/register').send({
+      const reg = await request(ctx.app).post('/api/users/register').send({
         username: 'postdev',
         email: 'postdev@example.com',
         password: 'Password123',
@@ -157,12 +128,12 @@ describe('Input Validation Tests', () => {
       });
       token = reg.body.token;
 
-      const worldRes = await request(app)
+      const worldRes = await request(ctx.app)
         .post('/api/worlds')
         .set('Authorization', `Bearer ${token}`)
         .send({ title: 'Post World' });
 
-      const eventRes = await request(app)
+      const eventRes = await request(ctx.app)
         .post(`/api/events/world/${worldRes.body.id}`)
         .set('Authorization', `Bearer ${token}`)
         .send({ title: 'Test Event', event_type: 'big' });
@@ -170,7 +141,7 @@ describe('Input Validation Tests', () => {
     });
 
     test('rejects missing content', async () => {
-      const res = await request(app)
+      const res = await request(ctx.app)
         .post(`/api/posts/event/${eventId}`)
         .set('Authorization', `Bearer ${token}`)
         .send({});
@@ -178,7 +149,7 @@ describe('Input Validation Tests', () => {
     });
 
     test('rejects invalid image_url', async () => {
-      const res = await request(app)
+      const res = await request(ctx.app)
         .post(`/api/posts/event/${eventId}`)
         .set('Authorization', `Bearer ${token}`)
         .send({ content: 'Hello', image_url: 'not-a-url' });
@@ -186,7 +157,7 @@ describe('Input Validation Tests', () => {
     });
 
     test('accepts valid post', async () => {
-      const res = await request(app)
+      const res = await request(ctx.app)
         .post(`/api/posts/event/${eventId}`)
         .set('Authorization', `Bearer ${token}`)
         .send({ content: 'My post content' });

--- a/server/src/test/validation.test.js
+++ b/server/src/test/validation.test.js
@@ -1,0 +1,196 @@
+import request from 'supertest';
+import { cleanupTestDb, resetDatabase, setupTestDb } from './helpers/testDb.js';
+
+describe('Input Validation Tests', () => {
+  let app;
+  let db;
+  let testDbPath;
+
+  beforeAll(async () => {
+    testDbPath = setupTestDb();
+    const dbModule = await import('../database/connection.js');
+    db = dbModule.default;
+    const schemaModule = await import('../database/schema.js');
+    schemaModule.initDatabase();
+    const appModule = await import('../index.js');
+    app = appModule.default;
+  });
+
+  beforeEach(() => {
+    resetDatabase(db);
+  });
+
+  afterAll(() => {
+    if (db) db.close();
+    cleanupTestDb(testDbPath);
+  });
+
+  // --- Register validation ---
+  describe('POST /api/users/register', () => {
+    const validUser = {
+      username: 'validuser',
+      email: 'valid@example.com',
+      password: 'Password123',
+      display_name: 'Valid User',
+    };
+
+    test('rejects missing username', async () => {
+      const { username, ...body } = validUser;
+      const res = await request(app).post('/api/users/register').send(body);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBeDefined();
+    });
+
+    test('rejects username shorter than 3 chars', async () => {
+      const res = await request(app)
+        .post('/api/users/register')
+        .send({ ...validUser, username: 'ab' });
+      expect(res.status).toBe(400);
+    });
+
+    test('rejects username with special characters', async () => {
+      const res = await request(app)
+        .post('/api/users/register')
+        .send({ ...validUser, username: 'bad user!' });
+      expect(res.status).toBe(400);
+    });
+
+    test('rejects invalid email format', async () => {
+      const res = await request(app)
+        .post('/api/users/register')
+        .send({ ...validUser, email: 'not-an-email' });
+      expect(res.status).toBe(400);
+    });
+
+    test('rejects password shorter than 6 chars', async () => {
+      const res = await request(app)
+        .post('/api/users/register')
+        .send({ ...validUser, password: '12345' });
+      expect(res.status).toBe(400);
+    });
+
+    test('rejects missing display_name', async () => {
+      const { display_name, ...body } = validUser;
+      const res = await request(app).post('/api/users/register').send(body);
+      expect(res.status).toBe(400);
+    });
+
+    test('accepts valid registration payload', async () => {
+      const res = await request(app).post('/api/users/register').send(validUser);
+      expect(res.status).toBe(201);
+      expect(res.body).toHaveProperty('token');
+    });
+  });
+
+  // --- Login validation ---
+  describe('POST /api/users/login', () => {
+    test('rejects missing username', async () => {
+      const res = await request(app)
+        .post('/api/users/login')
+        .send({ password: 'pass' });
+      expect(res.status).toBe(400);
+    });
+
+    test('rejects missing password', async () => {
+      const res = await request(app)
+        .post('/api/users/login')
+        .send({ username: 'user' });
+      expect(res.status).toBe(400);
+    });
+
+    test('rejects empty body', async () => {
+      const res = await request(app).post('/api/users/login').send({});
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // --- World creation validation ---
+  describe('POST /api/worlds', () => {
+    let token;
+
+    beforeEach(async () => {
+      const reg = await request(app).post('/api/users/register').send({
+        username: 'worlddev',
+        email: 'worlddev@example.com',
+        password: 'Password123',
+        display_name: 'World Dev',
+      });
+      token = reg.body.token;
+    });
+
+    test('rejects missing title', async () => {
+      const res = await request(app)
+        .post('/api/worlds')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ description: 'No title' });
+      expect(res.status).toBe(400);
+    });
+
+    test('accepts valid world creation', async () => {
+      const res = await request(app)
+        .post('/api/worlds')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ title: 'Test World', description: 'A world', is_public: true });
+      expect(res.status).toBe(201);
+    });
+
+    test('rejects is_public with non-boolean value', async () => {
+      const res = await request(app)
+        .post('/api/worlds')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ title: 'World', is_public: 'yes' });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // --- Post validation ---
+  describe('POST /api/posts/event/:eventId', () => {
+    let token;
+    let eventId;
+
+    beforeEach(async () => {
+      const reg = await request(app).post('/api/users/register').send({
+        username: 'postdev',
+        email: 'postdev@example.com',
+        password: 'Password123',
+        display_name: 'Post Dev',
+      });
+      token = reg.body.token;
+
+      const worldRes = await request(app)
+        .post('/api/worlds')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ title: 'Post World' });
+
+      const eventRes = await request(app)
+        .post(`/api/events/world/${worldRes.body.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ title: 'Test Event', event_type: 'big' });
+      eventId = eventRes.body.id;
+    });
+
+    test('rejects missing content', async () => {
+      const res = await request(app)
+        .post(`/api/posts/event/${eventId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({});
+      expect(res.status).toBe(400);
+    });
+
+    test('rejects invalid image_url', async () => {
+      const res = await request(app)
+        .post(`/api/posts/event/${eventId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ content: 'Hello', image_url: 'not-a-url' });
+      expect(res.status).toBe(400);
+    });
+
+    test('accepts valid post', async () => {
+      const res = await request(app)
+        .post(`/api/posts/event/${eventId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ content: 'My post content' });
+      expect(res.status).toBe(201);
+    });
+  });
+});


### PR DESCRIPTION
Closes #222

## Summary

- `validation.test.js`: integration tests cho tất cả validation rules
- `rateLimiter.test.js`: integration tests cho cả 3 tầng rate limiting

## Changes

| File | Thay đổi |
|------|---------|
| `server/src/test/validation.test.js` | 12+ test cases cho validation |
| `server/src/test/rateLimiter.test.js` | 7 test cases cho rate limiting |

## Test Coverage

**validation.test.js:**
- Register: username length, special chars, email format, password length, display_name
- Login: missing fields
- World: missing title, invalid is_public type
- Post: missing content, invalid image_url

**rateLimiter.test.js:**
- Auth limiter: under limit OK, over limit → 429 `RATE_LIMIT_EXCEEDED`
- Auth limiter: 429 response có `RateLimit-*` headers
- Register limiter: over limit → 429
- Global limiter: over 100/min → 429
- Global: normal request có `ratelimit-limit` header

## Dependencies

> **Yêu cầu A3.1 (#224) và A3.2 (#225) được merge trước khi tests pass.**

## Test Plan

- [ ] `npm test validation.test.js` trong project có A3.1 merged → all pass
- [ ] `npm test rateLimiter.test.js` trong project có A3.2 merged → all pass