### PR TITLE
Features/c3.2/edit profile

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,6 +10,7 @@ import WorldDetail from './pages/WorldDetail';
 import EventDetail from './pages/EventDetail';
 import CreateWorld from './pages/CreateWorld';
 import MyWorlds from './pages/MyWorlds';
+import UserProfile from './pages/UserProfile';
 import WorldManage from './pages/WorldManage';
 
 function ProtectedRoute({ children }) {
@@ -51,6 +52,14 @@ export default function App() {
             element={
               <ProtectedRoute>
                 <MyWorlds />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/profile"
+            element={
+              <ProtectedRoute>
+                <UserProfile />
               </ProtectedRoute>
             }
           />

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -30,6 +30,12 @@ export default function Navbar() {
                   My Worlds
                 </Link>
                 <Link
+                  to="/profile"
+                  className="text-dark-300 hover:text-dark-100 transition text-sm font-medium"
+                >
+                  Profile
+                </Link>
+                <Link
                   to="/worlds/create"
                   className="text-dark-300 hover:text-dark-100 transition text-sm font-medium"
                 >
@@ -42,11 +48,12 @@ export default function Navbar() {
         <div className="flex items-center gap-4">
           {user ? (
             <>
-              <span className="text-sm text-dark-300">
-                <span className="text-primary-400 font-medium">
-                  {user.display_name}
-                </span>
-              </span>
+              <Link
+                to="/profile"
+                className="text-sm text-primary-400 hover:text-primary-300 font-medium transition"
+              >
+                {user.display_name || user.username}
+              </Link>
               <button
                 onClick={logout}
                 className="text-sm text-dark-400 hover:text-red-400 transition"

--- a/client/src/contexts/AuthContext.jsx
+++ b/client/src/contexts/AuthContext.jsx
@@ -46,6 +46,14 @@ export function AuthProvider({ children }) {
   });
   const [isLoading, setIsLoading] = useState(false);
 
+  const updateUser = useCallback((nextUser) => {
+    setUser((currentUser) => {
+      const mergedUser = { ...(currentUser ?? {}), ...(nextUser ?? {}) };
+      localStorage.setItem(USER_KEY, JSON.stringify(mergedUser));
+      return mergedUser;
+    });
+  }, []);
+
   /**
    * _saveSession — Helper lưu token + user vào state và localStorage.
    * Tách ra để login và register đều dùng lại.
@@ -128,9 +136,10 @@ export function AuthProvider({ children }) {
       isLoading,
       login,
       register,
+      updateUser,
       logout,
     }),
-    [user, token, isLoading, login, register, logout],
+    [user, token, isLoading, login, register, updateUser, logout],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/client/src/pages/EventDetail.jsx
+++ b/client/src/pages/EventDetail.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import api from '../services/api';
+import api, { getApiCollection } from '../services/api';
 
 export default function EventDetail() {
   const { eventId } = useParams();
@@ -26,7 +26,7 @@ export default function EventDetail() {
         api.get(`/posts/event/${eventId}`)
       ]);
       setEvent(eventRes.data);
-      setPosts(postsRes.data);
+      setPosts(getApiCollection(postsRes.data));
     } catch { }
     setLoading(false);
   };
@@ -119,7 +119,7 @@ export default function EventDetail() {
     }
     try {
       const res = await api.get(`/posts/${postId}/comments`);
-      setComments({ ...comments, [postId]: res.data });
+      setComments({ ...comments, [postId]: getApiCollection(res.data) });
       setExpandedComments({ ...expandedComments, [postId]: true });
     } catch { }
   };

--- a/client/src/pages/EventDetail.test.jsx
+++ b/client/src/pages/EventDetail.test.jsx
@@ -13,6 +13,9 @@ vi.mock('../services/api.js', () => ({
     delete: vi.fn(),
   },
   getApiErrorMessage: vi.fn((err, fallback) => err?.message || fallback),
+  getApiCollection: vi.fn((payload) =>
+    Array.isArray(payload) ? payload : payload?.data || [],
+  ),
 }));
 
 vi.mock('../contexts/AuthContext', () => ({

--- a/client/src/pages/UserProfile.jsx
+++ b/client/src/pages/UserProfile.jsx
@@ -1,0 +1,216 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import api, { getApiErrorMessage } from '../services/api.js';
+
+const roleStyles = {
+  dev: 'bg-purple-900/50 text-purple-300 border-purple-700/60',
+  player: 'bg-blue-900/50 text-blue-300 border-blue-700/60',
+  member: 'bg-blue-900/50 text-blue-300 border-blue-700/60',
+};
+
+const formatDate = (value) => {
+  if (!value) return 'Unknown';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Unknown';
+
+  return date.toLocaleDateString();
+};
+
+export default function UserProfile() {
+  const [profile, setProfile] = useState(null);
+  const [worlds, setWorlds] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchProfile = async () => {
+      setLoading(true);
+      setError('');
+
+      try {
+        const [profileRes, worldsRes] = await Promise.all([
+          api.get('/users/me'),
+          api.get('/worlds/mine'),
+        ]);
+
+        if (!isMounted) return;
+
+        setProfile(profileRes.data);
+        setWorlds(Array.isArray(worldsRes.data) ? worldsRes.data : []);
+      } catch (err) {
+        if (!isMounted) return;
+        setError(getApiErrorMessage(err, 'Unable to load profile.'));
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
+
+    fetchProfile();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const displayName = profile?.display_name || profile?.username || 'User';
+  const initials = useMemo(() => {
+    return displayName
+      .split(' ')
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part[0])
+      .join('')
+      .toUpperCase();
+  }, [displayName]);
+
+  if (loading) {
+    return (
+      <div className="text-center text-dark-400 py-12">Loading profile...</div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-dark-900 border border-red-800 rounded-xl p-6 text-center">
+        <h1 className="text-2xl font-bold text-dark-100 mb-2">UserProfile</h1>
+        <p className="text-red-300 mb-4">{error}</p>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="bg-primary-600 hover:bg-primary-500 text-white px-4 py-2 rounded-lg text-sm font-medium transition"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <section className="bg-dark-900 border border-dark-700 rounded-xl p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-5">
+          {profile?.avatar_url ? (
+            <img
+              src={profile.avatar_url}
+              alt={displayName}
+              className="h-24 w-24 rounded-xl object-cover border border-dark-700"
+            />
+          ) : (
+            <div className="h-24 w-24 rounded-xl bg-primary-900/60 border border-primary-700/60 text-primary-200 flex items-center justify-center text-3xl font-bold">
+              {initials || 'U'}
+            </div>
+          )}
+
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-primary-400 mb-1">
+              UserProfile
+            </p>
+            <h1 className="text-3xl font-bold text-dark-100 truncate">
+              {displayName}
+            </h1>
+            <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-2 text-sm">
+              <p className="text-dark-400">
+                Username:{' '}
+                <span className="text-dark-200">{profile?.username}</span>
+              </p>
+              <p className="text-dark-400">
+                Email: <span className="text-dark-200">{profile?.email}</span>
+              </p>
+              <p className="text-dark-400">
+                Joined:{' '}
+                <span className="text-dark-200">
+                  {formatDate(profile?.created_at)}
+                </span>
+              </p>
+              <p className="text-dark-400">
+                Worlds:{' '}
+                <span className="text-dark-200">{worlds.length}</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div className="flex items-center justify-between gap-4 mb-5">
+          <h2 className="text-2xl font-bold text-dark-100">
+            Worlds You Joined
+          </h2>
+          <Link
+            to="/worlds"
+            className="text-primary-400 hover:text-primary-300 text-sm font-medium transition"
+          >
+            Explore worlds
+          </Link>
+        </div>
+
+        {worlds.length === 0 ? (
+          <div className="bg-dark-900 border border-dark-700 rounded-xl p-8 text-center">
+            <p className="text-dark-300 mb-3">
+              This account has not joined any worlds yet.
+            </p>
+            <Link
+              to="/worlds"
+              className="inline-flex bg-primary-600 hover:bg-primary-500 text-white px-4 py-2 rounded-lg text-sm font-medium transition"
+            >
+              Find a world
+            </Link>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {worlds.map((world) => {
+              const roleClass =
+                roleStyles[world.role] ||
+                'bg-dark-800 text-dark-300 border-dark-600';
+
+              return (
+                <Link
+                  key={world.id}
+                  to={`/worlds/${world.id}`}
+                  className="bg-dark-900 border border-dark-700 rounded-xl p-5 hover:border-primary-600 transition group"
+                >
+                  <div className="flex items-start justify-between gap-3 mb-3">
+                    <h3 className="text-lg font-semibold text-dark-100 group-hover:text-primary-400 transition line-clamp-2">
+                      {world.title}
+                    </h3>
+                    <span
+                      className={`shrink-0 text-xs px-2 py-1 rounded-full border font-medium ${roleClass}`}
+                    >
+                      {(world.role || 'member').toUpperCase()}
+                    </span>
+                  </div>
+                  <p className="text-dark-400 text-sm mb-4 line-clamp-2">
+                    {world.description || 'No description'}
+                  </p>
+                  <div className="grid grid-cols-3 gap-3 text-xs text-dark-400">
+                    <span>
+                      <span className="block text-dark-500">Members</span>
+                      <span className="text-dark-200">
+                        {world.member_count ?? 0}
+                      </span>
+                    </span>
+                    <span>
+                      <span className="block text-dark-500">Credits</span>
+                      <span className="text-dark-200">
+                        {world.credits ?? 0}
+                      </span>
+                    </span>
+                    <span>
+                      <span className="block text-dark-500">Created</span>
+                      <span className="text-dark-200">
+                        {formatDate(world.created_at)}
+                      </span>
+                    </span>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/client/src/pages/UserProfile.jsx
+++ b/client/src/pages/UserProfile.jsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import api, { getApiErrorMessage } from '../services/api.js';
+import { useAuth } from '../contexts/AuthContext.jsx';
+import api, {
+  getApiAssetUrl,
+  getApiCollection,
+  getApiErrorMessage,
+} from '../services/api.js';
 
 const roleStyles = {
   dev: 'bg-purple-900/50 text-purple-300 border-purple-700/60',
@@ -18,10 +23,18 @@ const formatDate = (value) => {
 };
 
 export default function UserProfile() {
+  const { updateUser } = useAuth();
   const [profile, setProfile] = useState(null);
   const [worlds, setWorlds] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [isEditing, setIsEditing] = useState(false);
+  const [displayNameInput, setDisplayNameInput] = useState('');
+  const [avatarFile, setAvatarFile] = useState(null);
+  const [avatarPreview, setAvatarPreview] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const [saveMessage, setSaveMessage] = useState('');
 
   useEffect(() => {
     let isMounted = true;
@@ -39,7 +52,8 @@ export default function UserProfile() {
         if (!isMounted) return;
 
         setProfile(profileRes.data);
-        setWorlds(Array.isArray(worldsRes.data) ? worldsRes.data : []);
+        setDisplayNameInput(profileRes.data?.display_name || '');
+        setWorlds(getApiCollection(worldsRes.data));
       } catch (err) {
         if (!isMounted) return;
         setError(getApiErrorMessage(err, 'Unable to load profile.'));
@@ -55,7 +69,22 @@ export default function UserProfile() {
     };
   }, []);
 
+  useEffect(() => {
+    if (!avatarFile) {
+      setAvatarPreview('');
+      return undefined;
+    }
+
+    const nextPreview = URL.createObjectURL(avatarFile);
+    setAvatarPreview(nextPreview);
+
+    return () => {
+      URL.revokeObjectURL(nextPreview);
+    };
+  }, [avatarFile]);
+
   const displayName = profile?.display_name || profile?.username || 'User';
+  const avatarSrc = avatarPreview || getApiAssetUrl(profile?.avatar_url);
   const initials = useMemo(() => {
     return displayName
       .split(' ')
@@ -65,6 +94,74 @@ export default function UserProfile() {
       .join('')
       .toUpperCase();
   }, [displayName]);
+
+  const handleStartEdit = () => {
+    setDisplayNameInput(profile?.display_name || '');
+    setAvatarFile(null);
+    setSaveError('');
+    setSaveMessage('');
+    setIsEditing(true);
+  };
+
+  const handleCancelEdit = () => {
+    setDisplayNameInput(profile?.display_name || '');
+    setAvatarFile(null);
+    setSaveError('');
+    setSaveMessage('');
+    setIsEditing(false);
+  };
+
+  const handleAvatarChange = (event) => {
+    const file = event.target.files?.[0] || null;
+    setAvatarFile(file);
+    setSaveError('');
+    setSaveMessage('');
+  };
+
+  const handleSaveProfile = async (event) => {
+    event.preventDefault();
+
+    const nextDisplayName = displayNameInput.trim();
+    if (!nextDisplayName) {
+      setSaveError('Display name cannot be empty.');
+      return;
+    }
+
+    setSaving(true);
+    setSaveError('');
+    setSaveMessage('');
+
+    try {
+      let avatarUrl = '';
+
+      if (avatarFile) {
+        const formData = new FormData();
+        formData.append('image', avatarFile);
+        const uploadRes = await api.post('/uploads/images', formData);
+        avatarUrl = uploadRes.data.url;
+      }
+
+      const payload = {
+        display_name: nextDisplayName,
+      };
+
+      if (avatarUrl) {
+        payload.avatar = avatarUrl;
+      }
+
+      const profileRes = await api.patch('/users/me', payload);
+
+      setProfile(profileRes.data);
+      updateUser?.(profileRes.data);
+      setAvatarFile(null);
+      setIsEditing(false);
+      setSaveMessage('Profile updated.');
+    } catch (err) {
+      setSaveError(getApiErrorMessage(err, 'Unable to update profile.'));
+    } finally {
+      setSaving(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -92,9 +189,9 @@ export default function UserProfile() {
     <div className="space-y-8">
       <section className="bg-dark-900 border border-dark-700 rounded-xl p-6">
         <div className="flex flex-col sm:flex-row sm:items-center gap-5">
-          {profile?.avatar_url ? (
+          {avatarSrc ? (
             <img
-              src={profile.avatar_url}
+              src={avatarSrc}
               alt={displayName}
               className="h-24 w-24 rounded-xl object-cover border border-dark-700"
             />
@@ -104,7 +201,7 @@ export default function UserProfile() {
             </div>
           )}
 
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <p className="text-sm font-medium text-primary-400 mb-1">
               UserProfile
             </p>
@@ -131,7 +228,93 @@ export default function UserProfile() {
               </p>
             </div>
           </div>
+
+          <div className="sm:self-start">
+            {!isEditing && (
+              <button
+                type="button"
+                onClick={handleStartEdit}
+                className="bg-primary-600 hover:bg-primary-500 text-white px-4 py-2 rounded-lg text-sm font-medium transition"
+              >
+                Edit Profile
+              </button>
+            )}
+          </div>
         </div>
+
+        {isEditing && (
+          <form
+            onSubmit={handleSaveProfile}
+            className="mt-6 border-t border-dark-700 pt-6 space-y-4"
+          >
+            {saveError && (
+              <div className="bg-red-900/30 border border-red-700 text-red-300 text-sm rounded-lg p-3">
+                {saveError}
+              </div>
+            )}
+
+            <div>
+              <label
+                htmlFor="profile_display_name"
+                className="block text-sm text-dark-400 mb-1"
+              >
+                Display Name
+              </label>
+              <input
+                id="profile_display_name"
+                type="text"
+                value={displayNameInput}
+                onChange={(event) => setDisplayNameInput(event.target.value)}
+                maxLength={50}
+                required
+                className="w-full bg-dark-800 border border-dark-600 rounded-lg px-4 py-2.5 text-dark-100 focus:outline-none focus:border-primary-500 transition"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="profile_avatar"
+                className="block text-sm text-dark-400 mb-1"
+              >
+                Avatar
+              </label>
+              <input
+                id="profile_avatar"
+                type="file"
+                accept="image/png,image/jpeg,image/gif,image/webp"
+                onChange={handleAvatarChange}
+                className="block w-full text-sm text-dark-300 file:mr-4 file:rounded-lg file:border-0 file:bg-dark-700 file:px-4 file:py-2 file:text-sm file:font-medium file:text-dark-100 hover:file:bg-dark-600"
+              />
+              <p className="mt-2 text-xs text-dark-500">
+                PNG, JPEG, GIF, or WebP. Maximum 5 MB.
+              </p>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-3 sm:justify-end">
+              <button
+                type="button"
+                onClick={handleCancelEdit}
+                disabled={saving}
+                className="border border-dark-600 bg-dark-800 hover:bg-dark-700 text-dark-200 px-4 py-2 rounded-lg text-sm font-medium transition disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={saving}
+                className="bg-primary-600 hover:bg-primary-500 text-white px-4 py-2 rounded-lg text-sm font-medium transition disabled:opacity-50"
+              >
+                {saving ? 'Saving...' : 'Save Profile'}
+              </button>
+            </div>
+          </form>
+        )}
+
+        {saveMessage && !isEditing && (
+          <div className="mt-4 bg-green-900/30 border border-green-700 text-green-300 text-sm rounded-lg p-3">
+            {saveMessage}
+          </div>
+        )}
       </section>
 
       <section>

--- a/client/src/pages/UserProfile.jsx
+++ b/client/src/pages/UserProfile.jsx
@@ -79,7 +79,7 @@ export default function UserProfile() {
         <p className="text-red-300 mb-4">{error}</p>
         <button
           type="button"
-          onClick={() => window.location.reload()}
+          onClick={() => globalThis.location.reload()}
           className="bg-primary-600 hover:bg-primary-500 text-white px-4 py-2 rounded-lg text-sm font-medium transition"
         >
           Try again

--- a/client/src/pages/WorldList.jsx
+++ b/client/src/pages/WorldList.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import api from '../services/api.js';
+import api, { getApiCollection } from '../services/api.js';
 
 export default function WorldList() {
   const [worlds, setWorlds] = useState([]);
@@ -11,7 +11,7 @@ export default function WorldList() {
     setLoading(true);
     try {
       const res = await api.get('/worlds', { params: q ? { search: q } : {} });
-      setWorlds(res.data);
+      setWorlds(getApiCollection(res.data));
     } catch {}
     setLoading(false);
   };

--- a/client/src/pages/WorldList.test.jsx
+++ b/client/src/pages/WorldList.test.jsx
@@ -15,6 +15,9 @@ vi.mock('../services/api.js', () => ({
   default: {
     get: vi.fn(),
   },
+  getApiCollection: vi.fn((payload) =>
+    Array.isArray(payload) ? payload : payload?.data || [],
+  ),
 }));
 
 const mockWorlds = [

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -24,6 +24,12 @@ export const getApiErrorMessage = (
   );
 };
 
+export const getApiCollection = (payload) => {
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.data)) return payload.data;
+  return [];
+};
+
 const api = axios.create({
   baseURL: API_URL,
   timeout: REQUEST_TIMEOUT_MS,

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -30,6 +30,18 @@ export const getApiCollection = (payload) => {
   return [];
 };
 
+export const getApiAssetUrl = (path) => {
+  if (!path) return '';
+  if (/^https?:\/\//i.test(path)) return path;
+
+  try {
+    const apiUrl = new URL(API_URL);
+    return `${apiUrl.origin}${path}`;
+  } catch {
+    return path;
+  }
+};
+
 const api = axios.create({
   baseURL: API_URL,
   timeout: REQUEST_TIMEOUT_MS,

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -6,7 +6,8 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:3001'
+      '/api': 'http://localhost:3001',
+      '/uploads': 'http://localhost:3001',
     }
   }
 });


### PR DESCRIPTION
Closed #153 
Thêm chỉnh sửa Profile cho người dùng:
- thêm form edit trong trang, upload ảnh trước rồi lưu URL avatar vào profile, đồng thời cập nhật AuthContext để Navbar đổi tên/avatar state ngay sau khi lưu.
-thêm proxy /uploads cho dev server để ảnh upload hiển thị được, và thêm helper dựng URL asset cho trường hợp VITE_API_URL là URL tuyệt đối. Đây là phần hay bị lỗi sau khi upload avatar nếu chỉ lưu path /uploads/...
- thêm form edit trong UserProfile: chỉnh Display Name, chọn avatar, preview ảnh, upload file rồi gọi PATCH profile. Tôi cũng dùng helper collection mới cho danh sách Worlds để nhất quán với fix trước.
- chỉnh payload PATCH chỉ gửi avatar khi thật sự có URL ảnh.