### PR TITLE
fix: small event created by dev now starts as 'open' not 'approved'

### DIFF
--- a/server/src/routes/events.js
+++ b/server/src/routes/events.js
@@ -63,7 +63,7 @@ router.post(
 
     let status;
     if (member.role === 'dev') {
-      status = event_type === 'big' ? 'open' : 'approved';
+      status = 'open';
     } else {
       if (event_type === 'big')
         return res


### PR DESCRIPTION
When a dev creates a small event with a date/time, it was set to 'approved' status which caused EventDetail to render it as closed read-only. Devs now always create events as 'open' regardless of event type; 'approved' stays reserved for player proposals that the dev has accepted but not yet opened.