### PR TITLE
Fix: Small events created by dev now open for posts

### DIFF
--- a/server/src/routes/events.js
+++ b/server/src/routes/events.js
@@ -63,7 +63,7 @@ router.post(
 
     let status;
     if (member.role === 'dev') {
-      status = event_type === 'big' ? 'open' : 'approved';
+      status = 'open';
     } else {
       if (event_type === 'big')
         return res


### PR DESCRIPTION
## Summary
- Fix: Dev-created small events now start as 'open' status (not 'approved')
- Previously, small events appeared read-only immediately after creation
- Big events continue as 'open' status as before

## Test plan
- [ ] Create a small event as dev
- [ ] Verify status is 'open'
- [ ] Verify users can post to the event