### PR TITLE
Feature: World cover images in cards and lore timeline

### DIFF
--- a/client/src/pages/MyWorlds.jsx
+++ b/client/src/pages/MyWorlds.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import EmptyState from '../components/EmptyState.jsx';
-import api from '../services/api.js';
+import api, { getApiAssetUrl } from '../services/api.js';
 import { MyWorldsSkeleton } from '../components/SkeletonLoader';
 
 export default function MyWorlds() {
@@ -102,7 +102,15 @@ function WorldCard({ world }) {
       to={`/worlds/${world.id}`}
       className="bg-white border border-slate-200 rounded-xl overflow-hidden hover:border-indigo-300 hover:shadow-md transition-all group flex flex-col"
     >
-      <div className="h-1.5 bg-gradient-to-r from-indigo-400 to-violet-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+      {getApiAssetUrl(world.cover_image) ? (
+        <img
+          src={getApiAssetUrl(world.cover_image)}
+          alt={world.title}
+          className="w-full h-32 object-cover group-hover:opacity-95 transition-opacity"
+        />
+      ) : (
+        <div className="h-1.5 bg-gradient-to-r from-indigo-400 to-violet-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+      )}
       <div className="p-5 flex flex-col flex-1">
         <div className="flex items-start justify-between gap-3 mb-3">
           <h3 className="text-base font-semibold text-slate-900 group-hover:text-indigo-600 transition-colors line-clamp-1">
@@ -136,6 +144,7 @@ WorldCard.propTypes = {
     title: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     description: PropTypes.string,
+    cover_image: PropTypes.string,
     member_count: PropTypes.number.isRequired,
     credits: PropTypes.number.isRequired,
   }).isRequired,

--- a/client/src/pages/WorldDetail.jsx
+++ b/client/src/pages/WorldDetail.jsx
@@ -227,17 +227,14 @@ export default function WorldDetail() {
                   </label>
                 )}
               </div>
+            ) : isDev ? (
+              <label className="flex h-28 cursor-pointer items-center justify-center gap-2 bg-gradient-to-r from-indigo-50 to-violet-50 border-b border-slate-100 text-indigo-500 text-sm font-medium hover:from-indigo-100 hover:to-violet-100 transition-colors">
+                {uploadingCover ? 'Uploading...' : '📷 Add Cover Image'}
+                <input type="file" accept="image/*" className="hidden" disabled={uploadingCover}
+                  onChange={e => handleUploadImage('cover_image', e.target.files?.[0])} />
+              </label>
             ) : (
-              <div className="relative group">
-                <div className="h-2 bg-gradient-to-r from-indigo-500 to-violet-500" />
-                {isDev && (
-                  <label className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer bg-black/10 text-indigo-700 text-xs font-semibold">
-                    {uploadingCover ? 'Uploading...' : '📷 Add Cover Image'}
-                    <input type="file" accept="image/*" className="hidden" disabled={uploadingCover}
-                      onChange={e => handleUploadImage('cover_image', e.target.files?.[0])} />
-                  </label>
-                )}
-              </div>
+              <div className="h-2 bg-gradient-to-r from-indigo-500 to-violet-500" />
             )}
             <div className="p-6">
               <h1 className="text-xl font-bold text-slate-900 mb-2 leading-tight">
@@ -346,12 +343,20 @@ export default function WorldDetail() {
                     />
                     <Link
                       to={`/events/${event.id}`}
-                      className={`block bg-white border rounded-xl p-4 hover:shadow-md transition-all ${
+                      className={`block bg-white border rounded-xl overflow-hidden hover:shadow-md transition-all ${
                         event.event_type === 'big'
                           ? 'border-l-4 border-l-indigo-400 border-y border-r border-slate-200'
                           : 'border border-slate-200'
                       }`}
                     >
+                      {getApiAssetUrl(event.thumbnail_url) && (
+                        <img
+                          src={getApiAssetUrl(event.thumbnail_url)}
+                          alt={event.title}
+                          className="w-full h-24 object-cover"
+                        />
+                      )}
+                      <div className="p-4">
                       <div className="flex items-center gap-2 mb-2">
                         <span
                           className={`text-xs font-medium px-2 py-0.5 rounded-full border ${
@@ -395,6 +400,7 @@ export default function WorldDetail() {
                           </span>
                         )}
                         <span>📝 {event.post_count} posts</span>
+                      </div>
                       </div>
                     </Link>
                   </div>

--- a/client/src/pages/WorldDetail.jsx
+++ b/client/src/pages/WorldDetail.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import EmptyState from '../components/EmptyState';
 import { useAuth } from '../contexts/AuthContext';
-import api from '../services/api';
+import api, { getApiAssetUrl } from '../services/api';
 import { WorldDetailSkeleton } from '../components/SkeletonLoader';
 import { useToastContext } from '../components/Toast';
 
@@ -36,6 +36,26 @@ export default function WorldDetail() {
     title: '',
     description: '',
   });
+
+  const [uploadingCover, setUploadingCover] = useState(false);
+  const [uploadingBg, setUploadingBg] = useState(false);
+
+  const handleUploadImage = async (field, file) => {
+    if (!file) return;
+    const setter = field === 'cover_image' ? setUploadingCover : setUploadingBg;
+    setter(true);
+    try {
+      const formData = new FormData();
+      formData.append('image', file);
+      const uploadRes = await api.post('/uploads/images', formData);
+      await api.patch(`/worlds/${id}`, { [field]: uploadRes.data.url });
+      fetchData();
+      toast.success('Image updated.');
+    } catch {
+      toast.error('Failed to upload image.');
+    }
+    setter(false);
+  };
 
   const fetchData = async () => {
     try {
@@ -170,14 +190,55 @@ export default function WorldDetail() {
   const actionBtn = renderActionButtons();
 
   return (
+    <div>
+      {/* ── World background banner ── */}
+      {getApiAssetUrl(world.background_image) && (
+        <div className="relative -mx-4 sm:-mx-6 lg:-mx-8 mb-6 h-48 overflow-hidden rounded-xl">
+          <img
+            src={getApiAssetUrl(world.background_image)}
+            alt="World background"
+            className="w-full h-full object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
+          <h1 className="absolute bottom-4 left-6 text-white text-2xl font-bold drop-shadow">
+            {world.title}
+          </h1>
+        </div>
+      )}
     <div className="lg:grid lg:grid-cols-3 lg:gap-8">
       {/* ── Sidebar ──────────────────────────────────── */}
       <aside className="lg:col-span-1 mb-6 lg:mb-0">
         <div className="sticky top-24 space-y-4">
           {/* World info card */}
           <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden shadow-sm">
-            {/* Colored header strip */}
-            <div className="h-2 bg-gradient-to-r from-indigo-500 to-violet-500" />
+            {/* Cover image or gradient strip */}
+            {getApiAssetUrl(world.cover_image) ? (
+              <div className="relative h-32 group">
+                <img
+                  src={getApiAssetUrl(world.cover_image)}
+                  alt="World cover"
+                  className="w-full h-full object-cover"
+                />
+                {isDev && (
+                  <label className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer text-white text-xs font-medium">
+                    {uploadingCover ? 'Uploading...' : '📷 Change Cover'}
+                    <input type="file" accept="image/*" className="hidden" disabled={uploadingCover}
+                      onChange={e => handleUploadImage('cover_image', e.target.files?.[0])} />
+                  </label>
+                )}
+              </div>
+            ) : (
+              <div className="relative group">
+                <div className="h-2 bg-gradient-to-r from-indigo-500 to-violet-500" />
+                {isDev && (
+                  <label className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer bg-black/10 text-indigo-700 text-xs font-semibold">
+                    {uploadingCover ? 'Uploading...' : '📷 Add Cover Image'}
+                    <input type="file" accept="image/*" className="hidden" disabled={uploadingCover}
+                      onChange={e => handleUploadImage('cover_image', e.target.files?.[0])} />
+                  </label>
+                )}
+              </div>
+            )}
             <div className="p-6">
               <h1 className="text-xl font-bold text-slate-900 mb-2 leading-tight">
                 {world.title}
@@ -217,12 +278,19 @@ export default function WorldDetail() {
               <div className="space-y-2">
                 {actionBtn}
                 {isDev && (
-                  <Link
-                    to={`/worlds/${id}/manage`}
-                    className="block w-full text-center bg-slate-100 hover:bg-slate-200 text-slate-700 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors"
-                  >
-                    ⚙️ Manage World
-                  </Link>
+                  <>
+                    <Link
+                      to={`/worlds/${id}/manage`}
+                      className="block w-full text-center bg-slate-100 hover:bg-slate-200 text-slate-700 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors"
+                    >
+                      ⚙️ Manage World
+                    </Link>
+                    <label className="flex items-center justify-center gap-2 w-full bg-slate-50 hover:bg-slate-100 border border-slate-200 text-slate-600 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors cursor-pointer">
+                      {uploadingBg ? 'Uploading...' : '🖼️ Set Background Image'}
+                      <input type="file" accept="image/*" className="hidden" disabled={uploadingBg}
+                        onChange={e => handleUploadImage('background_image', e.target.files?.[0])} />
+                    </label>
+                  </>
                 )}
               </div>
             </div>
@@ -725,6 +793,7 @@ export default function WorldDetail() {
         </div>
       )}
       </div>
+    </div>
     </div>
   );
 }

--- a/client/src/pages/WorldDetail.jsx
+++ b/client/src/pages/WorldDetail.jsx
@@ -192,10 +192,10 @@ export default function WorldDetail() {
   return (
     <div>
       {/* ── World background banner ── */}
-      {getApiAssetUrl(world.background_image) && (
+      {getApiAssetUrl(world.background_image_url) && (
         <div className="relative -mx-4 sm:-mx-6 lg:-mx-8 mb-6 h-48 overflow-hidden rounded-xl">
           <img
-            src={getApiAssetUrl(world.background_image)}
+            src={getApiAssetUrl(world.background_image_url)}
             alt="World background"
             className="w-full h-full object-cover"
           />
@@ -288,7 +288,7 @@ export default function WorldDetail() {
                     <label className="flex items-center justify-center gap-2 w-full bg-slate-50 hover:bg-slate-100 border border-slate-200 text-slate-600 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors cursor-pointer">
                       {uploadingBg ? 'Uploading...' : '🖼️ Set Background Image'}
                       <input type="file" accept="image/*" className="hidden" disabled={uploadingBg}
-                        onChange={e => handleUploadImage('background_image', e.target.files?.[0])} />
+                        onChange={e => handleUploadImage('background_image_url', e.target.files?.[0])} />
                     </label>
                   </>
                 )}

--- a/client/src/pages/WorldList.jsx
+++ b/client/src/pages/WorldList.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import EmptyState from '../components/EmptyState.jsx';
 import Pagination from '../components/Pagination.jsx';
 import { WorldListSkeleton } from '../components/SkeletonLoader.jsx';
-import api, { getApiCollection } from '../services/api.js';
+import api, { getApiAssetUrl, getApiCollection } from '../services/api.js';
 
 export default function WorldList() {
   const [worlds, setWorlds] = useState([]);
@@ -127,8 +127,15 @@ export default function WorldList() {
                 to={`/worlds/${world.id}`}
                 className="bg-white border border-slate-200 rounded-xl overflow-hidden hover:border-indigo-300 hover:shadow-md transition-all group flex flex-col"
               >
-                {/* Color accent strip */}
-                <div className="h-1.5 bg-gradient-to-r from-indigo-500 to-violet-500 opacity-0 group-hover:opacity-100 transition-opacity" />
+                {getApiAssetUrl(world.cover_image) ? (
+                  <img
+                    src={getApiAssetUrl(world.cover_image)}
+                    alt={world.title}
+                    className="w-full h-32 object-cover group-hover:opacity-95 transition-opacity"
+                  />
+                ) : (
+                  <div className="h-1.5 bg-gradient-to-r from-indigo-500 to-violet-500 opacity-0 group-hover:opacity-100 transition-opacity" />
+                )}
                 <div className="p-5 flex flex-col flex-1">
                   <h3 className="text-base font-semibold text-slate-900 group-hover:text-indigo-600 transition-colors mb-2 line-clamp-1">
                     {world.title}

--- a/server/src/database/schema.js
+++ b/server/src/database/schema.js
@@ -128,9 +128,9 @@ export function initDatabase() {
     db.exec('ALTER TABLE worlds ADD COLUMN deletion_scheduled_at DATETIME DEFAULT NULL');
   }
 
-  const hasWorldBackground = worldColumns.some((column) => column.name === 'background_image');
+  const hasWorldBackground = worldColumns.some((column) => column.name === 'background_image_url');
   if (!hasWorldBackground) {
-    db.exec('ALTER TABLE worlds ADD COLUMN background_image TEXT DEFAULT NULL');
+    db.exec('ALTER TABLE worlds ADD COLUMN background_image_url TEXT DEFAULT NULL');
   }
 
   const commentColumns = db.prepare("PRAGMA table_info(comments)").all();

--- a/server/src/database/schema.js
+++ b/server/src/database/schema.js
@@ -121,10 +121,16 @@ export function initDatabase() {
     CREATE INDEX IF NOT EXISTS idx_worlds_public_created ON worlds(is_public, created_at);
   `);
 
-  const columns = db.prepare("PRAGMA table_info(worlds)").all();
-  const hasDeletionColumn = columns.some((column) => column.name === 'deletion_scheduled_at');
+  const worldColumns = db.prepare("PRAGMA table_info(worlds)").all();
+
+  const hasDeletionColumn = worldColumns.some((column) => column.name === 'deletion_scheduled_at');
   if (!hasDeletionColumn) {
     db.exec('ALTER TABLE worlds ADD COLUMN deletion_scheduled_at DATETIME DEFAULT NULL');
+  }
+
+  const hasWorldBackground = worldColumns.some((column) => column.name === 'background_image');
+  if (!hasWorldBackground) {
+    db.exec('ALTER TABLE worlds ADD COLUMN background_image TEXT DEFAULT NULL');
   }
 
   const commentColumns = db.prepare("PRAGMA table_info(comments)").all();

--- a/server/src/routes/worlds.js
+++ b/server/src/routes/worlds.js
@@ -181,7 +181,7 @@ router.patch(
         .json({ error: 'Only the world owner can edit this world' });
     }
 
-    const { title, description, cover_image, background_image, is_public } = req.body;
+    const { title, description, cover_image, background_image_url, is_public } = req.body;
     const updates = [];
     const values = [];
 
@@ -200,9 +200,9 @@ router.patch(
       values.push(cover_image.trim());
     }
 
-    if (background_image !== undefined) {
-      updates.push('background_image = ?');
-      values.push(background_image.trim());
+    if (background_image_url !== undefined) {
+      updates.push('background_image_url = ?');
+      values.push(background_image_url.trim());
     }
 
     if (is_public !== undefined) {

--- a/server/src/routes/worlds.js
+++ b/server/src/routes/worlds.js
@@ -181,7 +181,7 @@ router.patch(
         .json({ error: 'Only the world owner can edit this world' });
     }
 
-    const { title, description, cover_image, is_public } = req.body;
+    const { title, description, cover_image, background_image, is_public } = req.body;
     const updates = [];
     const values = [];
 
@@ -198,6 +198,11 @@ router.patch(
     if (cover_image !== undefined) {
       updates.push('cover_image = ?');
       values.push(cover_image.trim());
+    }
+
+    if (background_image !== undefined) {
+      updates.push('background_image = ?');
+      values.push(background_image.trim());
     }
 
     if (is_public !== undefined) {


### PR DESCRIPTION
## Summary
- Enlarge cover image upload area from h-2 to h-28 (always visible for devs)
- Show world cover_image in WorldList cards and MyWorlds cards
- Show event thumbnail_url in world lore timeline
- Better visual hierarchy and discoverability

## Test plan
- [ ] Explore Worlds page: verify cover images display in cards
- [ ] My Worlds page: verify cover images display
- [ ] World detail - Lore tab: verify event cover images show
- [ ] Upload/change world cover image: area now h-28 and always clickable