### PR TITLE
Fix: Profile background save button persists on error

### DIFF
--- a/client/src/pages/UserProfile.jsx
+++ b/client/src/pages/UserProfile.jsx
@@ -97,6 +97,7 @@ export default function UserProfile() {
   const handleSaveBg = async () => {
     if (!bgFile) return;
     setUploadingBg(true);
+    setSaveError('');
     try {
       const formData = new FormData();
       formData.append('image', bgFile);
@@ -108,8 +109,10 @@ export default function UserProfile() {
       setSaveMessage('Background updated.');
     } catch (err) {
       setSaveError(getApiErrorMessage(err, 'Unable to update background.'));
+      setBgFile(null);
+    } finally {
+      setUploadingBg(false);
     }
-    setUploadingBg(false);
   };
 
   const displayName = profile?.display_name || profile?.username || 'User';


### PR DESCRIPTION
## Problem
When user uploads background image and clicks Save, if the save fails (API error), the save bar stays visible showing "New background image ready to save" indefinitely.

## Root Cause
In `handleSaveBg`, when save fails (catch block), `setBgFile(null)` is never called, so the save bar condition `{bgFile && (` remains true.

## Fix
- Clear `bgFile` in catch block on error
- Move `setUploadingBg(false)` to finally block
- Clear `saveError` at start of save attempt

## Test plan
- [ ] Upload profile background image
- [ ] Simulate API failure (disconnect network)
- [ ] Click Save Background
- [ ] Verify save bar dismisses even on error
- [ ] Verify error message shows if available